### PR TITLE
docs(theme): Remove code collapse javascript functionality.

### DIFF
--- a/themes/hugo-docs/static/js/dgraph.js
+++ b/themes/hugo-docs/static/js/dgraph.js
@@ -371,35 +371,6 @@ function getPathAfterVersionName(location, versionName) {
     appendAnchor(h2s[i]);
   }
 
-  // code collapse
-  var pres = $("pre");
-  pres.each(function () {
-    var self = this;
-
-    var isInRunnable = $(self).parents(".runnable").length > 0;
-    if (isInRunnable) {
-      return;
-    }
-
-    if (self.clientHeight > 330) {
-      if (self.clientHeight < 380) {
-        return;
-      }
-
-      self.className += " collapsed";
-
-      var showMore = document.createElement("div");
-      showMore.className = "showmore";
-      showMore.innerHTML = "<span>Show all</span>";
-      showMore.addEventListener("click", function () {
-        self.className = "";
-        showMore.parentNode.removeChild(showMore);
-      });
-
-      this.appendChild(showMore);
-    }
-  });
-
   // version selector
   var currentVersion = getCurrentVersion(location.pathname);
   document


### PR DESCRIPTION
This is the same change as dgraph-io/hugo-docs#96.

Remove the code collapse functionality.

Before (there's a "Show all" flap) (https://dgraph.io/docs/cloud/cloud-quick-start/):

![image](https://user-images.githubusercontent.com/2251820/114937328-7f667680-9df2-11eb-85fe-86d663fc9f9a.png)

After:

![image](https://user-images.githubusercontent.com/2251820/114937494-b2106f00-9df2-11eb-874e-db845fa4a969.png)
