### PR TITLE
Docs (Chore) Note that Dgraph Cloud is currently running v20.11 in Dgraph Cloud Overview; update left-nav links to v20.11 DQL and GraphQL docs

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -31,13 +31,13 @@ title = "Dgraph Cloud Docs"
 
 [[menu.main]]
   name = "GraphQL Docs"
-  url = "https://dgraph.io/docs/graphql/"
+  url = "https://dgraph.io/docs/v20.11/graphql/"
   identifier = "graphql"
   weight = 12
 
 [[menu.main]]
   name = "DQL Docs"
-  url = "https://dgraph.io/docs/dql/"
+  url = "https://dgraph.io/docs/v20.11/dql/"
   identifier = "dql"
   weight = 10
 

--- a/content/introduction.md
+++ b/content/introduction.md
@@ -5,6 +5,10 @@ weight = 1
     parent = "cloud"
 +++
 
+{{% notice "tip" %}}
+Dgraph Cloud currently runs release v20.11. 
+[Click here to see docs for Dgraph v20.11](https://dgraph.io/docs/v20.11/dgraph-overview/).
+{{% /notice %}}
 
 Dgraph Cloud, powered by Dgraph database, is a fully-managed GraphQL database
 service that lets you focus on building apps, not managing infrastructure. Dgraph
@@ -25,7 +29,7 @@ Dgraph Cloud is available in several pricing tiers:
 * **Dedicated Instances**: Backends in this tier run on dedicated server clusters to meet the heavy workloads and other needs of enterprise customers. This tier also provides high availability and the option to run Dgraph in your own virtual private cloud (VPC) or bring your own Kubernetes (BYOK) environment.
 
 To learn more about pricing for each tier, see the [Dgraph Pricing Page](https://dgraph.io/pricing).
-To learn more about Dgraph database, see [Dgraph Database Overview](https://dgraph.io/docs/dgraph-overview/).
+To learn more about Dgraph database, see [Dgraph Database Overview](https://dgraph.io/docs/v20.11/dgraph-overview/) (*v20.11 doc version*).
 
 
 ## Key features
@@ -58,7 +62,8 @@ Dgraph Alpha server nodes.
    endpoints.
 
 To learn more about the Dgraph clusters that power Dgraph Cloud, see
-[Understanding Dgraph Cluster](https://dgraph.io/docs/deploy/cluster-setup/#understanding-dgraph-cluster).
+[Understanding Dgraph Cluster](https://dgraph.io/docs/v20.11/deploy/cluster-setup/#understanding-dgraph-cluster)
+(*v20.11 doc version*).
 
 ## Next steps
 
@@ -83,5 +88,5 @@ Please see the following topics to learn more about how to use Dgraph Cloud:
 
 You might also be interested in:
 
-- [Dgraph GraphQL Schema Reference](https://dgraph.io/docs/graphql/schema/schema-overview), which lists all the types and directives supported by Dgraph
-- [Dgraph GraphQL API Reference](https://dgraph.io/docs/graphql/api/api-overview), which serves as a guide to using your new `/graphql` endpoint
+- [Dgraph GraphQL Schema Reference](https://dgraph.io/docs/v20.11/graphql/schema/schema-overview) (*v20.11 doc version*), which lists all the types and directives supported by Dgraph
+- [Dgraph GraphQL API Reference](https://dgraph.io/docs/v20.11/graphql/api/api-overview) (*v20.11 doc version*), which serves as a guide to using your new `/graphql` endpoint


### PR DESCRIPTION
This PR adds a note to the Dgraph Cloud overview that Dgraph Cloud is currently running release v20.11, and links to those docs. This PR also changes other links from the Dgraph Cloud Overview to pages in the dgraph-docs repo to point to their v20.11 version.

Also, this PR updates the left-nav links for "DQL Docs" and "GraphQL Docs" to the v20.11 doc version

Fixes DOC-291
<!--
Title: Please use the following format for your PR title:  topic(area): details
- The "topic" should be one of the following: Docs, Nav or Chore
- The "area" is the feature (i.e., "GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bug-fix PRs). 
Sample Titles:
  Docs(GraphQL): Document the @deprecated annotation
  Chore(Other): cherry-pick updates from master to release/v20.11

Description: Please include the following in your PR description:
1. A brief, clear description of the change.
2. Link to any related PRs or discuss.dgraph.io posts.
3. If this PR corresponds to a JIRA issue, include "Fixes DOC-###" in the PR description.
3. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->
 
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://)
<!-- Dgraph:end -->