### PR TITLE
Docs (Cloud Schema Modes): Add discussion of changing modes by direct editing of the schema, note modes are only configurable for dedicated instances

### DIFF
--- a/content/admin/schema-modes.md
+++ b/content/admin/schema-modes.md
@@ -6,16 +6,18 @@ weight = 6
 +++
 
 Dgraph Cloud supports three different schema modes, which control how the
-underlying Dgraph instance is configured. Each mode is pre-configured keeping ease of use in mind:
+underlying Dgraph instance is configured. Each mode is pre-configured to provide
+simplicity and ease-of-use. 
 
-- [Read-Only mode](#read-only-mode), where no schema changes or mutations are allowed.
-- [Strict mode](#strict-mode), only allowing mutations on predicates that are already present in the schema.
-- [Flexible mode](#flexible-mode) removes any restriction on schemas and mutations, and provides access to advanced Dgraph features.
+The schema modes are as follows:
 
-{{% notice "tip" %}}
+- [Read-Only mode](#read-only-mode): In this mode, no schema changes or mutations are allowed.
+- [Strict mode](#strict-mode): In this mode, only mutations on predicates that are already present in the schema are allowed.
+- [Flexible mode](#flexible-mode): In this mode, there are no global restrictions on schemas and mutations;
+   this mode also provides access to advanced Dgraph features.
+
 By default, your Dgraph Cloud schema will run in [Strict mode](#strict-mode).
 If you want to have the same behavior as a local Dgraph instance, change your schema to [Flexible mode](#flexible-mode). 
-{{% /notice %}}
 
 ## Read-only Mode
 
@@ -39,14 +41,28 @@ In **Strict mode**, before executing a mutation on a predicate that doesn’t ex
 
 Flexible mode is suitable for users who are already familiar with Dgraph. Flexible mode removes any
 restrictions on schemas and mutations, and also provides access to
-advanced Dgraph features like directly altering the schema with the `/alter`
-HTTP and GRPC endpoints.
+advanced Dgraph features like:
 
-Running your backend in flexible mode is also a requirement for upcoming
-features such as support for access control lists (ACL).
+* Directly altering the schema with the `/alter` HTTP and GRPC endpoints.
+* Support for access control lists (ACLs).
 
 ## Changing your Schema Mode
 
 To change your schema mode, go to the 
 [settings page](https://cloud.dgraph.io/_/settings), click the <kbd>Advanced</kbd> tab,
 and then select a mode from the **Schema Mode** list box.
+
+### Changing your Schema Mode with the `/alter` endpoint
+
+{{% notice "tip" %}}
+Dgraph Labs recommends using the Dgraph Cloud [settings page](https://cloud.dgraph.io/_/settings)
+to alter your schema mode for most scenarios, instead of using the `/alter` endpoint.
+{{% /notice %}}
+
+You can alter your schema mode directly in the schema using the `/alter` HTTP
+and GRPC endpoints. To set your schema mode, configure `UpdateOption` to use one
+ of the following values in your schema:
+
+* To use Read Only mode, set `UpdateOption` to `readonly`
+* To use Strict mode, set `UpdateOption` to `graphql`
+* To use Flexible mode, set `UpdateOption` to `flexible`

--- a/content/admin/schema-modes.md
+++ b/content/admin/schema-modes.md
@@ -1,12 +1,14 @@
 +++
-title = "Switching Schema Modes"
+title = "Switch Dgraph Cloud Schema Modes"
+description = "Dgraph Cloud provides a variety of schema modes that let you configure how the underlying Dgraph Cloud instance responds to schema changes or mutation requests that seek to change data stored in your backend."
 weight = 6
 [menu.main]
+    name = "Switch Schema Modes"
     parent = "cloud-admin"
 +++
 
 Dgraph Cloud uses the following three schema modes, which control how the
-underlying Dgraph instance is configured:
+underlying Dgraph database instance is configured:
 
 - [Read-Only mode](#read-only-mode) (*dedicated instances only*): In this mode, no
   schema changes or mutations are allowed
@@ -21,12 +23,12 @@ your Dgraph Cloud schema will run in [Strict mode](#strict-mode). If you want
 your dedicated instance to have the same behavior as a local Dgraph instance,
 change your schema to [Flexible mode](#flexible-mode). 
 
-## Read-only Mode
+## Read-Only mode
 
 In read-only mode, all mutations and attempts to alter the Cloud schema are
 blocked. You can still access your data through read-only queries.
 
-## Strict Mode
+## Strict mode
 
 Strict mode is the default mode on Dgraph Cloud, and the only mode available for
 free and shared instances. In this mode, Dgraph Cloud enforces a [strict schema](https://dgraph.io/docs/deploy/dgraph-administration/#restricting-mutation-operations), only allowing mutations on
@@ -37,12 +39,12 @@ mode, as described in the [advanced queries](/advanced-queries/) section.
 However, all queries and mutations must be valid for the applied schema.
 
 {{% notice "note" %}}
-In **Strict mode**, before executing a mutation on a predicate that doesn’t
+In **Strict** mode, before executing a mutation on a predicate that doesn’t
 exist in the schema, you need to perform an `alter` operation with that
 predicate and its schema type.
 {{% /notice %}}
 
-## Flexible Mode
+## Flexible mode
 
 Flexible mode is suitable for users who are already familiar with Dgraph.
 Flexible mode removes any restrictions on schemas and mutations, and also
@@ -51,13 +53,13 @@ provides access to advanced Dgraph features like the following:
 * Directly altering the schema with the `/alter` HTTP and GRPC endpoints
 * Support for access control lists (ACLs)
 
-## Changing your Schema Mode
+## Changing your schema mode
 
 To change your schema mode on a dedicated instance, go to the [settings page](https://cloud.dgraph.io/_/settings),
 click the <kbd>General</kbd> tab, and then select a mode from the
 **Schema Mode** list box.
 
-### Changing your Schema Mode with the `/admin` endpoint
+### Changing your schema mode with the `/admin` endpoint
 
 {{% notice "tip" %}}
 Dgraph Labs recommends using the Dgraph Cloud [settings page](https://cloud.dgraph.io/_/settings)

--- a/content/admin/schema-modes.md
+++ b/content/admin/schema-modes.md
@@ -57,16 +57,20 @@ To change your schema mode on a dedicated instance, go to the [settings page](ht
 click the <kbd>General</kbd> tab, and then select a mode from the
 **Schema Mode** list box.
 
-### Changing your Schema Mode with the `/alter` endpoint
+### Changing your Schema Mode with the `/admin` endpoint
 
 {{% notice "tip" %}}
 Dgraph Labs recommends using the Dgraph Cloud [settings page](https://cloud.dgraph.io/_/settings)
-to alter your schema mode for most scenarios, instead of using the `/alter` endpoint.
+to change your dedicated instance's schema mode for most scenarios, instead of
+directly modifying your schema.
 {{% /notice %}}
 
-You can alter the schema mode for your dedicated instance directly in the schema
-using the `/alter` HTTP and GRPC endpoints. To set your schema mode, configure
-`UpdateOption` to use one of the following values in your schema:
+You can change the schema mode for your dedicated instance directly in the schema
+using the `updateGQLSchema` mutation on the `/admin` HTTP and GRPC endpoints. To
+learn more, see [Fetching and Updating your Schema]({{< relref "admin/schema" >}})
+
+To set your schema mode, configure `UpdateOption` to use one of the following
+values in your schema:
 
 * To use Read Only mode, set `UpdateOption` to `readonly`
 * To use Strict mode, set `UpdateOption` to `graphql`

--- a/content/admin/schema-modes.md
+++ b/content/admin/schema-modes.md
@@ -23,12 +23,12 @@ your Dgraph Cloud schema will run in [Strict mode](#strict-mode). If you want
 your dedicated instance to have the same behavior as a local Dgraph instance,
 change your schema to [Flexible mode](#flexible-mode). 
 
-## Read-Only mode
+### Read-Only mode
 
 In read-only mode, all mutations and attempts to alter the Cloud schema are
 blocked. You can still access your data through read-only queries.
 
-## Strict mode
+### Strict mode
 
 Strict mode is the default mode on Dgraph Cloud, and the only mode available for
 free and shared instances. In this mode, Dgraph Cloud enforces a [strict schema](https://dgraph.io/docs/deploy/dgraph-administration/#restricting-mutation-operations), only allowing mutations on
@@ -40,26 +40,29 @@ However, all queries and mutations must be valid for the applied schema.
 
 {{% notice "note" %}}
 In **Strict** mode, before executing a mutation on a predicate that doesn’t
-exist in the schema, you need to perform an `alter` operation with that
-predicate and its schema type.
+exist in the schema, you need add that predicate to the schema. To add a predicate,
+perform an [`alter` operation](https://dgraph.io/docs/clients/raw-http/#alter-the-database)
+with that predicate and its schema type (*dedicated instances only*), or
+[update your schema]({{< relref "admin/schema" >}}) to include that predicate and
+its schema type.
 {{% /notice %}}
 
-## Flexible mode
+### Flexible mode
 
 Flexible mode is suitable for users who are already familiar with Dgraph.
-Flexible mode removes any restrictions on schemas and mutations, and also
+It removes global restrictions on schemas and mutations, and also
 provides access to advanced Dgraph features like the following:
 
-* Directly altering the schema with the `/alter` HTTP and GRPC endpoints
-* Support for access control lists (ACLs)
+* Directly altering the schema with the [`alter`](https://dgraph.io/docs/clients/raw-http/#alter-the-database) HTTP and GRPC endpoints
+* Support for access control lists ([ACLs](https://dgraph.io/docs/enterprise-features/access-control-lists/))
 
-## Changing your schema mode
+## Switch schema modes with the Dgraph Cloud console
 
 To change your schema mode on a dedicated instance, go to the [settings page](https://cloud.dgraph.io/_/settings),
 click the <kbd>General</kbd> tab, and then select a mode from the
 **Schema Mode** list box.
 
-### Changing your schema mode with the `/admin` endpoint
+## Switch schema modes with the `/admin` endpoint
 
 {{% notice "tip" %}}
 Dgraph Labs recommends using the Dgraph Cloud [settings page](https://cloud.dgraph.io/_/settings)
@@ -69,7 +72,7 @@ directly modifying your schema.
 
 You can change the schema mode for your dedicated instance directly in the schema
 using the `updateGQLSchema` mutation on the `/admin` HTTP and GRPC endpoints. To
-learn more, see [Fetching and Updating your Schema]({{< relref "admin/schema" >}})
+learn more, see [Fetch and Update Your Schema]({{< relref "admin/schema" >}}).
 
 To set your schema mode, configure `UpdateOption` to use one of the following
 values in your schema:

--- a/content/admin/schema-modes.md
+++ b/content/admin/schema-modes.md
@@ -11,46 +11,50 @@ simplicity and ease-of-use.
 
 The schema modes are as follows:
 
-- [Read-Only mode](#read-only-mode): In this mode, no schema changes or mutations are allowed.
-- [Strict mode](#strict-mode): In this mode, only mutations on predicates that are already present in the schema are allowed.
+- [Read-Only mode](#read-only-mode): In this mode, no schema changes or mutations are allowed
+- [Strict mode](#strict-mode): In this mode, only mutations on predicates that are already present in the schema are allowed
 - [Flexible mode](#flexible-mode): In this mode, there are no global restrictions on schemas and mutations;
-   this mode also provides access to advanced Dgraph features.
+   this mode also provides access to advanced Dgraph features
 
-By default, your Dgraph Cloud schema will run in [Strict mode](#strict-mode).
-If you want to have the same behavior as a local Dgraph instance, change your schema to [Flexible mode](#flexible-mode). 
+By default, your Dgraph Cloud schema will run in [Strict mode](#strict-mode). If
+you want to have the same behavior as a local Dgraph instance, change your
+schema to [Flexible mode](#flexible-mode). 
 
 ## Read-only Mode
 
-In read-only mode, all mutations and attempts to alter the Cloud schema are blocked.
-You can still access your data through read-only queries.
+In read-only mode, all mutations and attempts to alter the Cloud schema are
+blocked. You can still access your data through read-only queries.
 
 ## Strict Mode
 
-Strict mode is the default setting on Dgraph Cloud.
-In this mode, Dgraph Cloud will enforce a [strict schema](https://dgraph.io/docs/deploy/dgraph-administration/#restricting-mutation-operations), only allowing mutations on predicates already present in the schema.
+Strict mode is the default setting on Dgraph Cloud. In this mode, Dgraph Cloud
+will enforce a [strict schema](https://dgraph.io/docs/deploy/dgraph-administration/#restricting-mutation-operations),
+only allowing mutations on predicates already present in the schema.
 
-You can use GraphQL and DQL (formerly *GraphQL+-*) queries and mutations in this mode, as
-described in the [advanced queries](/advanced-queries/) section. However, all
-queries and mutations must be valid for the applied schema.
+You can use GraphQL and DQL (formerly *GraphQL+-*) queries and mutations in this
+mode, as described in the [advanced queries](/advanced-queries/) section.
+However, all queries and mutations must be valid for the applied schema.
 
 {{% notice "note" %}}
-In **Strict mode**, before executing a mutation on a predicate that doesn’t exist in the schema, you need to perform an `alter` operation with that predicate and its schema type.
+In **Strict mode**, before executing a mutation on a predicate that doesn’t
+exist in the schema, you need to perform an `alter` operation with that
+predicate and its schema type.
 {{% /notice %}}
 
 ## Flexible Mode
 
-Flexible mode is suitable for users who are already familiar with Dgraph. Flexible mode removes any
-restrictions on schemas and mutations, and also provides access to
-advanced Dgraph features like:
+Flexible mode is suitable for users who are already familiar with Dgraph.
+Flexible mode removes any restrictions on schemas and mutations, and also
+provides access to advanced Dgraph features like:
 
 * Directly altering the schema with the `/alter` HTTP and GRPC endpoints.
 * Support for access control lists (ACLs).
 
 ## Changing your Schema Mode
 
-To change your schema mode, go to the 
-[settings page](https://cloud.dgraph.io/_/settings), click the <kbd>Advanced</kbd> tab,
-and then select a mode from the **Schema Mode** list box.
+To change your schema mode, go to the [settings page](https://cloud.dgraph.io/_/settings),
+click the <kbd>Advanced</kbd> tab, and then select a mode from the 
+**Schema Mode** list box.
 
 ### Changing your Schema Mode with the `/alter` endpoint
 

--- a/content/admin/schema-modes.md
+++ b/content/admin/schema-modes.md
@@ -5,20 +5,21 @@ weight = 6
     parent = "cloud-admin"
 +++
 
-Dgraph Cloud supports three different schema modes, which control how the
-underlying Dgraph instance is configured. Each mode is pre-configured to provide
-simplicity and ease-of-use. 
+Dgraph Cloud uses the following three schema modes, which control how the
+underlying Dgraph instance is configured:
 
-The schema modes are as follows:
+- [Read-Only mode](#read-only-mode) (*dedicated instances only*): In this mode, no
+  schema changes or mutations are allowed
+- [Strict mode](#strict-mode): In this mode, only mutations on predicates that
+  are already present in the schema are allowed
+- [Flexible mode](#flexible-mode) (*dedicated instances only*): In this mode,
+  there are no global restrictions on schemas and mutations; this mode also
+  provides access to advanced Dgraph features
 
-- [Read-Only mode](#read-only-mode): In this mode, no schema changes or mutations are allowed
-- [Strict mode](#strict-mode): In this mode, only mutations on predicates that are already present in the schema are allowed
-- [Flexible mode](#flexible-mode): In this mode, there are no global restrictions on schemas and mutations;
-   this mode also provides access to advanced Dgraph features
-
-By default, your Dgraph Cloud schema will run in [Strict mode](#strict-mode). If
-you want to have the same behavior as a local Dgraph instance, change your
-schema to [Flexible mode](#flexible-mode). 
+Each mode is pre-configured to provide simplicity and ease-of-use. By default,
+your Dgraph Cloud schema will run in [Strict mode](#strict-mode). If you want 
+your dedicated instance to have the same behavior as a local Dgraph instance,
+change your schema to [Flexible mode](#flexible-mode). 
 
 ## Read-only Mode
 
@@ -27,9 +28,9 @@ blocked. You can still access your data through read-only queries.
 
 ## Strict Mode
 
-Strict mode is the default setting on Dgraph Cloud. In this mode, Dgraph Cloud
-will enforce a [strict schema](https://dgraph.io/docs/deploy/dgraph-administration/#restricting-mutation-operations),
-only allowing mutations on predicates already present in the schema.
+Strict mode is the default mode on Dgraph Cloud, and the only mode available for
+free and shared instances. In this mode, Dgraph Cloud enforces a [strict schema](https://dgraph.io/docs/deploy/dgraph-administration/#restricting-mutation-operations), only allowing mutations on
+predicates already present in the schema.
 
 You can use GraphQL and DQL (formerly *GraphQL+-*) queries and mutations in this
 mode, as described in the [advanced queries](/advanced-queries/) section.
@@ -45,15 +46,15 @@ predicate and its schema type.
 
 Flexible mode is suitable for users who are already familiar with Dgraph.
 Flexible mode removes any restrictions on schemas and mutations, and also
-provides access to advanced Dgraph features like:
+provides access to advanced Dgraph features like the following:
 
-* Directly altering the schema with the `/alter` HTTP and GRPC endpoints.
-* Support for access control lists (ACLs).
+* Directly altering the schema with the `/alter` HTTP and GRPC endpoints
+* Support for access control lists (ACLs)
 
 ## Changing your Schema Mode
 
-To change your schema mode, go to the [settings page](https://cloud.dgraph.io/_/settings),
-click the <kbd>Advanced</kbd> tab, and then select a mode from the 
+To change your schema mode on a dedicated instance, go to the [settings page](https://cloud.dgraph.io/_/settings),
+click the <kbd>General</kbd> tab, and then select a mode from the
 **Schema Mode** list box.
 
 ### Changing your Schema Mode with the `/alter` endpoint
@@ -63,9 +64,9 @@ Dgraph Labs recommends using the Dgraph Cloud [settings page](https://cloud.dgra
 to alter your schema mode for most scenarios, instead of using the `/alter` endpoint.
 {{% /notice %}}
 
-You can alter your schema mode directly in the schema using the `/alter` HTTP
-and GRPC endpoints. To set your schema mode, configure `UpdateOption` to use one
- of the following values in your schema:
+You can alter the schema mode for your dedicated instance directly in the schema
+using the `/alter` HTTP and GRPC endpoints. To set your schema mode, configure
+`UpdateOption` to use one of the following values in your schema:
 
 * To use Read Only mode, set `UpdateOption` to `readonly`
 * To use Strict mode, set `UpdateOption` to `graphql`


### PR DESCRIPTION
This PR details which nodes are available for dedicated instances, and describes how to edit the schema directly. Also links were added to relevant information throughout, edits were applied, and headings were changed per style guidance

Fixes DOC-328


<!--
Title: Please use the following format for your PR title:  topic(area): details
- The "topic" should be one of the following: Docs, Nav or Chore
- The "area" is the feature (i.e., "GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bug-fix PRs). 
Sample Titles:
  Docs(GraphQL): Document the @deprecated annotation
  Chore(Other): cherry-pick updates from master to release/v20.11

Description: Please include the following in your PR description:
1. A brief, clear description of the change.
2. Link to any related PRs or discuss.dgraph.io posts.
3. If this PR corresponds to a JIRA issue, include "Fixes DOC-###" in the PR description.
3. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->
 
 
 
 
 
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://)
<!-- Dgraph:end -->