### PR TITLE
docs (Cloud Exports) Add steps to get exports with multi-tenancy in Cloud

### DIFF
--- a/content/admin/import-export.md
+++ b/content/admin/import-export.md
@@ -48,6 +48,90 @@ query {
   }
 }
 ```
+## Exporting Data with Multi-Tenancy feature enabled
+
+{{% notice "note" %}}
+With Multi-Tenancy feature enabled, for any GraphQL request you will need to provide the `accessJWT` for the specific user in the `X-Dgraph-AccessToken` header.
+{{% /notice %}}
+
+You can trigger two types of exports:
+* cluster-wide export: this is an export of the entier backend (including all namespaces). This request can be only triggered by the *Guardian of Galaxy* users
+* namespace-specific export: this is an export of a specific namespace. This request can be triggered by the *Guardian of Galaxy* users and by the *Guardian of Namespace* users.
+
+### Cluster-wide Exports
+
+This can only be done by the *Guardian of Galaxy* users (AKA Super Admin), the steps are:
+
+1. Get the `accessJWT` token for the *Guardian of Galaxy* user. Send the following GraphQL mutation to the `/admin` endpoint:
+```graphql
+mutation login($userId: String, $password: String, $namespace: Int) {
+  login(userId: $userId, password: $password, namespace: $namespace) {
+    response {
+      accessJWT
+      refreshJWT
+    }
+  }
+}
+```
+Your variables should be referring to the *Guardian of Galaxy* user:
+```json
+{
+	"userId": "groot",
+	"password": "password",
+	"namespace": 0
+}
+```
+2. Once obtained the `accessJWT` token you need to pass it in `X-Dgraph-AccessToken` Header and only then you can send the following GraphQL mutation to `/admin/slash` endpoint:
+```graphql
+mutation {
+  export (namespace: -1) {
+    response { code message }
+    exportId
+    taskId
+  }
+}
+```
+3. Once done, you can now send the following GraqhQL mutation to get the `signedUrls` from where you can download your export files:
+```graphql
+query {
+  exportStatus (
+    exportId:"<paste-your-exportId>"
+    taskId: "<paste-your-taskId>"
+  ){
+    kind
+    lastUpdated
+    signedUrls
+    status
+  }
+}
+```
+
+### Namespace-specific Exports
+
+Namespace-specific exports can be triggered by the *Guardian of Galaxy* users. In this case you can follow the same steps for the cluster-wide exports and replace the namespace value from `-1` to the namespace you want to export. It's important that you get the `accessJWT` token for the *Guardian of Galaxy* user and pass it in the `X-Dgraph-AccessToken` header.
+
+E.g. if you want to export the namespace `0x123` your GraphQL request sent to the `/admin/slash` endpoint would look like:
+```graphql
+mutation {
+  export (namespace: 123) {
+    response { code message }
+    exportId
+    taskId
+  }
+}
+```
+You can also trigger namespace-specific export using the *Guardian of Namespace* users, in this case there is no need to specify any namespace in the GraphQL request as these users can only export their own namespace. It's important that you get the `accessJWT` token for the *Guardian of Namespace* user and pass it in the `X-Dgraph-AccessToken` header.
+
+The GraphQL request sent to the `/admin/slash` endpoint would be:
+```graphql
+mutation {
+  export {
+    response { code message }
+    exportId
+    taskId
+  }
+}
+```
 
 ## Importing data with Live Loader
 

--- a/content/admin/import-export.md
+++ b/content/admin/import-export.md
@@ -55,7 +55,7 @@ With Multi-Tenancy feature enabled, for any GraphQL request you will need to pro
 {{% /notice %}}
 
 You can trigger two types of exports:
-* cluster-wide export: this is an export of the entier backend (including all namespaces). This request can be only triggered by the *Guardian of Galaxy* users
+* cluster-wide export: this is an export of the entire backend (including all namespaces). This request can be only triggered by the [*Guardian of Galaxy*](https://dgraph.io/docs/enterprise-features/multitenancy/#guardians-of-the-galaxy) users.
 * namespace-specific export: this is an export of a specific namespace. This request can be triggered by the *Guardian of Galaxy* users and by the *Guardian of Namespace* users.
 
 ### Cluster-wide Exports


### PR DESCRIPTION
This PR adds notes and steps for:
- type of exports that can be taken with Multi-Tenancy
- What type of exports Guardian of Galaxy and Guardian of Namespace can trigger
- steps to trigger cluster-wide exports
- steps to trigger namespace-specific export 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://)
<!-- Dgraph:end -->