### PR TITLE
docs(import): Use dgraph/dgraph:v21.03-slash image.

### DIFF
--- a/content/admin/import-export.md
+++ b/content/admin/import-export.md
@@ -147,10 +147,10 @@ The gRPC endpoint URL must have the string `.grpc.` added after the domain prefi
 3. Run the live loader as follows:
 
     ```
-    docker run -it --rm -v /path/to/g01.json.gz:/tmp/g01.json.gz dgraph/dgraph:v20.07-slash \
+    docker run -it --rm -v /path/to/g01.json.gz:/tmp/g01.json.gz dgraph/dgraph:v21.03-slash \
       dgraph live --slash_grpc_endpoint=<grpc-endpoint>:443 -f /tmp/g01.json.gz -t <api-token>
     ```
 
 {{% notice "note" %}}
-Running this via Docker requires you to use an unreleased tag (either `master` or `v20.11-slash`).
+Running this via Docker requires you to use an unreleased tag (either `master` or `v21.03-slash`).
 {{% /notice %}}

--- a/content/cloud-api/backup.md
+++ b/content/cloud-api/backup.md
@@ -154,7 +154,7 @@ Import your data back using Dgraph [Live Loader]({{< relref "import-export.md#im
 Live loader command (via Docker):
 
 ```sh
-docker run -it --rm -v /tmp/file:/tmp/g01.json.gz dgraph/dgraph:v20.11-slash \
+docker run -it --rm -v /tmp/file:/tmp/g01.json.gz dgraph/dgraph:v21.03-slash \
   dgraph live --slash_grpc_endpoint=${DEPLOYMENT_URL} -f /tmp/g01.json.gz -t ${DEPLOYMENT_JWT}
 ```
 
@@ -167,7 +167,7 @@ docker run -it --rm -v /tmp/file:/tmp/g01.json.gz dgraph/dgraph:v20.11-slash \
 DEPLOYMENT_URL="lively-dream.grpc.us-east-1.aws.cloud.dgraph.io"
 DEPLOYMENT_JWT="<deployment-jwt>"
 
-docker run -it --rm -v /users/dgraph/downloads:/tmp dgraph/dgraph:v20.11-slash \
+docker run -it --rm -v /users/dgraph/downloads:/tmp dgraph/dgraph:v21.03-slash \
   dgraph live --slash_grpc_endpoint=${DEPLOYMENT_URL}:443 -f /tmp/1million.rdf.gz -t ${DEPLOYMENT_JWT}
 ```
 {{< /tab >}} 


### PR DESCRIPTION
Update examples to use the `dgraph/dgraph:v21.03-slash` so that live loader can work with the latest Dgraph Cloud backend versions.

CLOUD-526

<!--
Title: Please use the following format for your PR title:  topic(area): details
- The "topic" should be one of the following: Docs, Nav or Chore
- The "area" is the feature (i.e., "GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bug-fix PRs). 
Sample Titles:
  Docs(GraphQL): Document the @deprecated annotation
  Chore(Other): cherry-pick updates from master to release/v20.11

Description: Please include the following in your PR description:
1. A brief, clear description of the change.
2. Link to any related PRs or discuss.dgraph.io posts.
3. If this PR corresponds to a JIRA issue, include "Fixes DOC-###" in the PR description.
3. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://)
<!-- Dgraph:end -->