### PR TITLE
Added descriptions for authentication headers

### DIFF
--- a/content/cloud-api/overview.md
+++ b/content/cloud-api/overview.md
@@ -26,19 +26,19 @@ Please see the following topics:
 Dgraph Cloud has two layers of security: Dgraph Cloud Authentication and Dgraph Access Control Lists Authentication. The following section introduces the usage of the headers involved in the authentication process. These include the `Dg-Auth`, `X-Auth-Token`,  `Authorization`, and `X-Dgraph-AccessToken` headers.
 
 ### Dgraph Cloud Authentication
-The `Dg-Auth` or `X-Auth-Token` headers are for Dgraph Cloud’s API key authentication (where you pass in any API key you’d generate from https://cloud.dgraph.io/_/settings?tab=api-keys). The API key passed can be one of two kinds: Admin API key or Client API key. The tokens generated from the admin API grant access to the `/admin` or `/admin/slash` endpoints to perform schema alterations and similar operations. The tokens generated via the Client API key provides access to the `/graphql` endpoint to run GraphQL queries and mutations.
+The `Dg-Auth` or `X-Auth-Token` headers are for Dgraph Cloud’s API key authentication (where you pass in any API key you would generate from the ["API Keys" tab](https://cloud.dgraph.io/_/settings?tab=api-keys) on the Settings page). The API key passed can be one of two kinds: Admin API key or Client API key. The tokens generated from the admin API grant access to the `/admin` or `/admin/slash` endpoints to perform schema alterations and similar operations. The tokens generated via the Client API key provides access to the `/graphql` endpoint to run GraphQL queries and mutations.
 
-Dgraph Cloud also offers the Dgraph Cloud API (hosted at https://cerebro.cloud.dgraph.io/graphql) that helps to automate tasks such as deployment of a lambda. In order to use this API, users need to pass an `Authorization` header. In order to generate this header, the user must first [Authenticate]({{< relref "/cloud-api/authentication" >}}) and generate a token. The token is then set in `Authorization` header as a Bearer token (e.g. `Bearer {token}`). 
+Dgraph Cloud also offers the Dgraph Cloud API, hosted at [this endpoint](https://cerebro.cloud.dgraph.io/graphql), that helps to automate tasks such as deployment of a lambda. In order to use this API, users need to pass an `Authorization` header. In order to generate this header, the user must first [Authenticate]({{< relref "/cloud-api/authentication" >}}) and generate a token. The token is then set in `Authorization` header as a Bearer token (e.g. `Bearer {token}`). 
 
 {{% notice "note" %}}
 The `Dg-Auth`, `X-Auth-Token` and the `Authorization` headers are relevant to all types of backends, including Free, Shared, and Dedicated Backends.
 {{% /notice %}}
 
 ### Dgraph Access Control Lists Authentication
-The `X-Dgraph-AccessToken` header is used for accessing backends using Dgraph’s Access Control Lists or the Multitenancy feature. This lets you pass in an access JWT generated via a login mutation for a Dgraph user from the access control list permissions and/or log into a specific namespace with multi-tenancy. The Login mutation relevant for ACL is documented here: https://dgraph.io/docs/enterprise-features/access-control-lists/#logging-in
+The `X-Dgraph-AccessToken` header is used for accessing backends using Dgraph’s Access Control Lists or the Multitenancy feature. This lets you pass in an access JWT generated via a login mutation for a Dgraph user from the access control list permissions and/or log into a specific namespace with multi-tenancy. The Login mutation relevant for ACL is documented [here](https://dgraph.io/docs/enterprise-features/access-control-lists/#logging-in).
 
 If you’re using ACLs or multitenancy, then you’ll need to set the `X-Dgraph-AccessToken` with a JWT token to access your backend.
 
 {{% notice "note" %}}
 The `X-Dgraph-AccessToken` header is relevant only for the Dedicated backends. Users with Free or Shared backends can ignore this header.
-{{% /notice %}}x
+{{% /notice %}}

--- a/content/cloud-api/overview.md
+++ b/content/cloud-api/overview.md
@@ -31,7 +31,7 @@ The `Dg-Auth` or `X-Auth-Token` headers are for Dgraph Cloud’s API key authent
 Dgraph Cloud also offers the Dgraph Cloud API (hosted at https://cerebro.cloud.dgraph.io/graphql) that helps to automate tasks such as deployment of a lambda. In order to use this API, users need to pass an `Authorization` header. In order to generate this header, the user must first [Authenticate]({{< relref "/cloud-api/authentication" >}}) and generate a token. The token is then set in `Authorization` header as a Bearer token (e.g. `Bearer {token}`). 
 
 {{% notice "note" %}}
-The `Dg-Auth`, `X-Auth-Token` and the `Authorization` headers are relevant to all types of backends, including Free, Shared and Dedicated Backends.
+The `Dg-Auth`, `X-Auth-Token` and the `Authorization` headers are relevant to all types of backends, including Free, Shared, and Dedicated Backends.
 {{% /notice %}}
 
 ### Dgraph Access Control Lists Authentication

--- a/content/cloud-api/overview.md
+++ b/content/cloud-api/overview.md
@@ -23,7 +23,7 @@ Please see the following topics:
 
 ## Understanding Headers used across the APIs
 
-Dgraph Cloud has two layers of security: `Dgraph Cloud Authentication` and `Dgraph Access Control Lists Authentication`. The following section introduces the usage of the headers involved in the authentication process. These include the `Dg-Auth`, `X-Auth-Token` the `X-Dgraph-AccessToken` and the `Authorization` headers.
+Dgraph Cloud has two layers of security: Dgraph Cloud Authentication and Dgraph Access Control Lists Authentication. The following section introduces the usage of the headers involved in the authentication process. These include the `Dg-Auth`, `X-Auth-Token`,  `Authorization`, and `X-Dgraph-AccessToken` headers.
 
 ### Dgraph Cloud Authentication
 The `Dg-Auth` or `X-Auth-Token` headers are for Dgraph Cloud’s API key authentication (where you pass in any API key you’d generate from https://cloud.dgraph.io/_/settings?tab=api-keys). The API key passed can be one of two kinds: Admin API key or Client API key. The tokens generated from the admin API grant access to the `/admin` or `/admin/slash` endpoints to perform schema alterations and similar operations. The tokens generated via the Client API key provides access to the `/graphql` endpoint to run GraphQL queries and mutations.

--- a/content/cloud-api/overview.md
+++ b/content/cloud-api/overview.md
@@ -20,3 +20,25 @@ Please see the following topics:
 * [Backup]({{< relref "backup.md" >}}) lists commands related to backup.
 * [Lambda]({{< relref "lambda.md" >}}) lists commands related to Lambda.
 * [Schema]({{< relref "schema.md" >}}) lists commands related to schema.
+
+## Understanding Headers used across the APIs
+
+Dgraph Cloud has two layers of security: `Dgraph Cloud Authentication` and `Dgraph Access Control Lists Authentication`. The following section introduces the usage of the headers involved in the authentication process. These include the `Dg-Auth`, `X-Auth-Token` the `X-Dgraph-AccessToken` and the `Authorization` headers.
+
+### Dgraph Cloud Authentication
+The `Dg-Auth` or `X-Auth-Token` headers are for Dgraph Cloud’s API key authentication (where you pass in any API key you’d generate from https://cloud.dgraph.io/_/settings?tab=api-keys). The API key passed can be one of two kinds: Admin API key or Client API key. The tokens generated from the admin API grant access to the `/admin` or `/admin/slash` endpoints to perform schema alterations and similar operations. The tokens generated via the Client API key provides access to the `/graphql` endpoint to run GraphQL queries and mutations.
+
+Dgraph Cloud also offers the Dgraph Cloud API (hosted at https://cerebro.cloud.dgraph.io/graphql) that helps to automate tasks such as deployment of a lambda. In order to use this API, users need to pass an `Authorization` header. In order to generate this header, the user must first [Authenticate]({{< relref "/cloud-api/authentication" >}}) and generate a token. The token is then set in `Authorization` header as a Bearer token (e.g. `Bearer {token}`). 
+
+{{% notice "note" %}}
+The `Dg-Auth`, `X-Auth-Token` and the `Authorization` headers are relevant to all types of backends, including Free, Shared and Dedicated Backends.
+{{% /notice %}}
+
+### Dgraph Access Control Lists Authentication
+The `X-Dgraph-AccessToken` header is used for accessing backends using Dgraph’s Access Control Lists or the Multitenancy feature. This lets you pass in an access JWT generated via a login mutation for a Dgraph user from the access control list permissions and/or log into a specific namespace with multi-tenancy. The Login mutation relevant for ACL is documented here: https://dgraph.io/docs/enterprise-features/access-control-lists/#logging-in
+
+If you’re using ACLs or multitenancy, then you’ll need to set the `X-Dgraph-AccessToken` with a JWT token to access your backend.
+
+{{% notice "note" %}}
+The `X-Dgraph-AccessToken` header is relevant only for the Dedicated backends. Users with Free or Shared backends can ignore this header.
+{{% /notice %}}x


### PR DESCRIPTION
Added descriptions for `Dg-Auth`, `X-Auth-Token` the `X-Dgraph-AccessToken` and the `Authorization` headers


<!--
Title: Please use the following format for your PR title:  topic(area): details
- The "topic" should be one of the following: Docs, Nav or Chore
- The "area" is the feature (i.e., "GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bug-fix PRs). 
Sample Titles:
  Docs(GraphQL): Document the @deprecated annotation
  Chore(Other): cherry-pick updates from master to release/v20.11

Description: Please include the following in your PR description:
1. A brief, clear description of the change.
2. Link to any related PRs or discuss.dgraph.io posts.
3. If this PR corresponds to a JIRA issue, include "Fixes DOC-###" in the PR description.
3. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->
 
 
 
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://)
<!-- Dgraph:end -->